### PR TITLE
教室エンティティ導入のフォローアップ

### DIFF
--- a/db/migrate/20260611015002_add_null_false_to_glazes_and_clays.rb
+++ b/db/migrate/20260611015002_add_null_false_to_glazes_and_clays.rb
@@ -1,0 +1,6 @@
+class AddNullFalseToGlazesAndClays < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :clays,  :studio_id, false
+    change_column_null :glazes, :studio_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_05_050241) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_015002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,7 +55,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_05_050241) do
   create_table "clays", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
-    t.bigint "studio_id"
+    t.bigint "studio_id", null: false
     t.datetime "updated_at", null: false
     t.index ["studio_id"], name: "index_clays_on_studio_id"
   end
@@ -72,7 +72,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_05_050241) do
   create_table "glazes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
-    t.bigint "studio_id"
+    t.bigint "studio_id", null: false
     t.datetime "updated_at", null: false
     t.index ["studio_id"], name: "index_glazes_on_studio_id"
   end


### PR DESCRIPTION
既存のデータのバックフィルをした上で対応する予定だったが、デプロイ前で既存データがないためバックフィルせずに修正を適用。